### PR TITLE
Upgrade updating script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,4 +155,8 @@ If your repository is currently on a feature branch (different from the main bra
 All your personal changes (committed and uncommitted) are preserved via rebasing and stashing.
 Check the description of the script behaviour inside the script itself for more details.
 
+If `CLEAN=1`, obsolete builds are deleted from the `sw` directory at the end.
+If `PURGE_BUILDS=1`, a deeper purging is done by deleting all builds that are not needed to run the latest AliPhysics and O2 builds.
+WARNING: Do not enable the purging if you need to keep several builds of AliPhysics or O2 (e.g. for different branches or commits) or builds of other development packages!
+
 You can easily extend the script to include any other local Git repository on your machine that you wish to be updated in the same way.

--- a/README.md
+++ b/README.md
@@ -139,16 +139,16 @@ also requires updating the AliPhysics installation which then requires updating 
 Also when requesting changes in the main repository via a pull request, it is strongly recommended to update one's personal fork repository first,
 apply the changes on top the main branch and rebuild the installation to make sure that the new commits can be seamlessly merged into the main repository.
 
-All these maintenance steps can be fully automated using the `update_alio2.sh` bash script which takes care of keeping your (local and remote) repositories
+All these maintenance steps can be fully automated using the `update_packages.sh` bash script which takes care of keeping your (local and remote) repositories
 and installations up to date with the latest development in the respective main branches.
-This includes updating alidist, AliPhysics, O<sup>2</sup>, and this Run 3 validation code repository, as well as re-building your AliPhysics and O<sup>2</sup> installations via aliBuild.
+This includes updating alidist, AliPhysics, O<sup>2</sup>, and this Run 3 validation code repository, as well as re-building your AliPhysics and O<sup>2</sup> installations via aliBuild and deleting obsolete builds.
 
 All you need to do is to make sure that the strings in the `User settings` block of the script correspond to your local setup and
 adjust the activation switches, if needed, to change the list of steps to be executed.
 
 You can then start the full update of your code and installations by running the script from any directory on your system:
 ```bash
-bash <path to the Run3Analysisvalidation directory>/update_alio2.sh
+bash <path to the Run3Analysisvalidation directory>/exec/update_packages.sh
 ```
 
 If your repository is currently on a feature branch (different from the main branch), both the main branch and your feature branch will be updated from the main branch.

--- a/config/config_update.sh
+++ b/config/config_update.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Configuration of update_packages.sh
+
+####################################################################################################
+
+# Settings
+
+# Delete unnecessary files.
+CLEAN=1
+
+# Delete all builds that are not needed to run the latest AliPhysics and O2 builds.
+# WARNING: Do not enable this if you need to keep several builds of AliPhysics or O2 (e.g. for different branches or commits) or builds of other development packages!
+PURGE_BUILDS=0
+
+# Print out an overview of the latest commits of repositories.
+PRINT_COMMITS=0
+
+# Main ALICE software directory
+#ALICE_DIR="$HOME/alice"
+
+# aliBuild
+#ALIBUILD_ARCH=$(aliBuild architecture) # system architecture
+#ALIBUILD_OPT="-a $ALIBUILD_ARCH"
+
+####################################################################################################
+
+# Package specification:
+# paths, names of remotes (check git remote -v), build options.
+
+# alidist
+ALIDIST_NAME="alidist"
+ALIDIST_UPDATE=1
+ALIDIST_DIR="$ALICE_DIR/alidist"
+ALIDIST_REMOTE_MAIN="upstream"
+ALIDIST_REMOTE_FORK=""
+ALIDIST_BRANCH_MAIN="master"
+ALIDIST_SPECS=("$ALIDIST_NAME" $ALIDIST_UPDATE "$ALIDIST_DIR" "$ALIDIST_REMOTE_MAIN" "$ALIDIST_REMOTE_FORK" "$ALIDIST_BRANCH_MAIN")
+
+# AliPhysics
+ALIPHYSICS_NAME="AliPhysics"
+ALIPHYSICS_UPDATE=1
+ALIPHYSICS_DIR="$ALICE_DIR/AliPhysics"
+ALIPHYSICS_REMOTE_MAIN="upstream"
+ALIPHYSICS_REMOTE_FORK="origin"
+ALIPHYSICS_BRANCH_MAIN="master"
+ALIPHYSICS_BUILD_OPT="--defaults user-next-root6"
+ALIPHYSICS_BUILD=1
+ALIPHYSICS_SPECS=("$ALIPHYSICS_NAME" $ALIPHYSICS_UPDATE "$ALIPHYSICS_DIR" "$ALIPHYSICS_REMOTE_MAIN" "$ALIPHYSICS_REMOTE_FORK" "$ALIPHYSICS_BRANCH_MAIN" "$ALIPHYSICS_BUILD_OPT" $ALIPHYSICS_BUILD)
+
+# O2
+O2_NAME="O2"
+O2_UPDATE=1
+O2_DIR="$ALICE_DIR/O2"
+O2_REMOTE_MAIN="upstream"
+O2_REMOTE_FORK="origin"
+O2_BRANCH_MAIN="dev"
+O2_BUILD_OPT="--defaults o2"
+O2_BUILD=1
+O2_SPECS=("$O2_NAME" $O2_UPDATE "$O2_DIR" "$O2_REMOTE_MAIN" "$O2_REMOTE_FORK" "$O2_BRANCH_MAIN" "$O2_BUILD_OPT" $O2_BUILD)
+
+# Run 3 validation
+RUN3VALIDATE_NAME="Run 3 validation"
+RUN3VALIDATE_UPDATE=1
+RUN3VALIDATE_DIR="$(dirname $(realpath $0))"
+RUN3VALIDATE_REMOTE_MAIN="upstream"
+RUN3VALIDATE_REMOTE_FORK="origin"
+RUN3VALIDATE_BRANCH_MAIN="master"
+RUN3VALIDATE_SPECS=("$RUN3VALIDATE_NAME" $RUN3VALIDATE_UPDATE "$RUN3VALIDATE_DIR" "$RUN3VALIDATE_REMOTE_MAIN" "$RUN3VALIDATE_REMOTE_FORK" "$RUN3VALIDATE_BRANCH_MAIN")
+
+####################################################################################################
+
+# List of packages to update/build. (Put alidist first!)
+LIST_PKG_SPECS=(
+#"ALIDIST_SPECS"
+#"ALIPHYSICS_SPECS"
+"O2_SPECS"
+"RUN3VALIDATE_SPECS"
+)
+
+####################################################################################################

--- a/config/config_update.sh
+++ b/config/config_update.sh
@@ -14,7 +14,7 @@ CLEAN=1
 PURGE_BUILDS=0
 
 # Print out an overview of the latest commits of repositories.
-PRINT_COMMITS=0
+PRINT_COMMITS=1
 
 # Main ALICE software directory
 #ALICE_DIR="$HOME/alice"
@@ -30,7 +30,7 @@ PRINT_COMMITS=0
 
 # alidist
 ALIDIST_NAME="alidist"
-ALIDIST_UPDATE=1
+ALIDIST_UPDATE=0
 ALIDIST_DIR="$ALICE_DIR/alidist"
 ALIDIST_REMOTE_MAIN="upstream"
 ALIDIST_REMOTE_FORK=""
@@ -39,13 +39,13 @@ ALIDIST_SPECS=("$ALIDIST_NAME" $ALIDIST_UPDATE "$ALIDIST_DIR" "$ALIDIST_REMOTE_M
 
 # AliPhysics
 ALIPHYSICS_NAME="AliPhysics"
-ALIPHYSICS_UPDATE=1
+ALIPHYSICS_UPDATE=0
 ALIPHYSICS_DIR="$ALICE_DIR/AliPhysics"
 ALIPHYSICS_REMOTE_MAIN="upstream"
 ALIPHYSICS_REMOTE_FORK="origin"
 ALIPHYSICS_BRANCH_MAIN="master"
 ALIPHYSICS_BUILD_OPT="--defaults user-next-root6"
-ALIPHYSICS_BUILD=1
+ALIPHYSICS_BUILD=0
 ALIPHYSICS_SPECS=("$ALIPHYSICS_NAME" $ALIPHYSICS_UPDATE "$ALIPHYSICS_DIR" "$ALIPHYSICS_REMOTE_MAIN" "$ALIPHYSICS_REMOTE_FORK" "$ALIPHYSICS_BRANCH_MAIN" "$ALIPHYSICS_BUILD_OPT" $ALIPHYSICS_BUILD)
 
 # O2
@@ -62,7 +62,7 @@ O2_SPECS=("$O2_NAME" $O2_UPDATE "$O2_DIR" "$O2_REMOTE_MAIN" "$O2_REMOTE_FORK" "$
 # Run 3 validation
 RUN3VALIDATE_NAME="Run 3 validation"
 RUN3VALIDATE_UPDATE=1
-RUN3VALIDATE_DIR="$(dirname $(realpath $0))"
+RUN3VALIDATE_DIR="$DIR_REPO"
 RUN3VALIDATE_REMOTE_MAIN="upstream"
 RUN3VALIDATE_REMOTE_FORK="origin"
 RUN3VALIDATE_BRANCH_MAIN="master"
@@ -70,12 +70,18 @@ RUN3VALIDATE_SPECS=("$RUN3VALIDATE_NAME" $RUN3VALIDATE_UPDATE "$RUN3VALIDATE_DIR
 
 ####################################################################################################
 
-# List of packages to update/build. (Put alidist first!)
+# List of packages to update/build (Put alidist first!)
 LIST_PKG_SPECS=(
-#"ALIDIST_SPECS"
-#"ALIPHYSICS_SPECS"
+"ALIDIST_SPECS"
+"ALIPHYSICS_SPECS"
 "O2_SPECS"
 "RUN3VALIDATE_SPECS"
+)
+
+# List of development aliBuild packages
+LIST_PKG_DEV_SPECS=(
+"ALIPHYSICS_SPECS"
+"O2_SPECS"
 )
 
 ####################################################################################################

--- a/exec/update_packages.sh
+++ b/exec/update_packages.sh
@@ -251,10 +251,11 @@ fi
 # Print out latest commits.
 if [ $PRINT_COMMITS -eq 1 ]; then
   MsgStep "Latest commits"
-  echo "alidist: $( cd "$ALIDIST_DIR" && PrintLastCommit )"
-  echo "AliPhysics: $( cd "$ALIPHYSICS_DIR" && PrintLastCommit )"
-  echo "O2: $( cd "$O2_DIR" && PrintLastCommit )"
-  echo "Run 3 validation: $( cd "$RUN3VALIDATE_DIR" && PrintLastCommit )"
+  for pkg in "${LIST_PKG_SPECS[@]}"; do
+    arr="$pkg[@]"
+    spec=("${!arr}")
+    echo "${spec[0]}: $( cd "${spec[2]}" && PrintLastCommit )"
+  done
 fi
 
 MsgStep "Done"

--- a/update_alio2.sh
+++ b/update_alio2.sh
@@ -12,14 +12,23 @@
 # User settings:
 # paths, names of remotes (check git remote -v), build options.
 
+# Delete unnecessary files.
+CLEAN=1
+CLEAN_AGGRESSIVE=0 # Delete store and SOURCES except for AliPhysics and O2.
+
+# Delete all builds other than the latest ones (i.e. the ones currently being built in this script).
+# WARNING: Do not enable this if you need to keep several builds of the same package (AliPhysics, O2) (e.g. for different branches or commits).
+PURGE_BUILDS=0 # NOT WORKING YET!
+
 # Print out an overview of the latest commits of repositories.
 PRINT_COMMITS=1
 
 # Main ALICE software directory
 ALICE_DIR="$HOME/alice"
 
-# System architecture (if not detected properly by aliBuild)
-ALIBUILD_ARCH=""
+# aliBuild
+ALIBUILD_ARCH=$(aliBuild architecture) # system architecture
+ALIBUILD_OPT="-a $ALIBUILD_ARCH"
 
 # alidist
 ALIDIST_UPDATE=1
@@ -54,13 +63,14 @@ RUN3VALIDATE_REMOTE_FORK="origin"
 RUN3VALIDATE_BRANCH_MAIN="master"
 #################################################################
 
-# Error report
-ERREXIT="eval echo -e \"\\e[1;31mError\\e[0m\"; exit 1"
+# Report error and exit
+function ErrExit { echo -e "\e[1;31mError\e[0m"; exit 1; }
 
 # Message formatting
 function MsgStep { echo -e "\n\e[1;32m$@\e[0m"; }
 function MsgSubStep { echo -e "\n\e[1m$@\e[0m"; }
 function MsgSubSubStep { echo -e "\e[4m$@\e[0m"; }
+function MsgWarn { echo -e "\e[1;36m$@\e[0m"; }
 
 function PrintLastCommit {
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -77,22 +87,22 @@ function UpdateBranch {
   [ "$4" ] && REMOTE_FORK_="$4"
 
   MsgSubStep "- Updating branch $BRANCH_"
-  git checkout $BRANCH_ || $ERREXIT
+  git checkout $BRANCH_ || ErrExit
 
   # Synchronise with the fork first, just in case there are some commits pushed from another local repository.
   if [ "$REMOTE_FORK_" ]; then
     MsgSubSubStep "-- Updating branch $BRANCH_ from $REMOTE_FORK_/$BRANCH_"
-    git pull --rebase $REMOTE_FORK_ $BRANCH_ || $ERREXIT
+    git pull --rebase $REMOTE_FORK_ $BRANCH_ || ErrExit
   fi
 
   # Synchronise with upstream/main.
   MsgSubSubStep "-- Updating branch $BRANCH_ from $REMOTE_MAIN_/$BRANCH_MAIN_"
-  git pull --rebase $REMOTE_MAIN_ $BRANCH_MAIN_ || $ERREXIT
+  git pull --rebase $REMOTE_MAIN_ $BRANCH_MAIN_ || ErrExit
 
   # Push to the fork.
   if [ "$REMOTE_FORK_" ]; then
     MsgSubSubStep "-- Pushing branch $BRANCH_ to $REMOTE_FORK_"
-    git push -f $REMOTE_FORK_ $BRANCH_ || $ERREXIT
+    git push -f $REMOTE_FORK_ $BRANCH_ || ErrExit
   fi
 }
 
@@ -105,7 +115,7 @@ function UpdateGit {
   [ "$4" ] && REMOTE_FORK="$4"
 
   # Move to the Git repository and get the name of the current branch.
-  cd "$DIR" && BRANCH=$(git rev-parse --abbrev-ref HEAD) || $ERREXIT
+  cd "$DIR" && BRANCH=$(git rev-parse --abbrev-ref HEAD) || ErrExit
   #echo "Directory: $DIR"
   echo "Current branch: $BRANCH"
 
@@ -116,19 +126,17 @@ function UpdateGit {
   MsgSubStep "- Stashing potential uncommitted local changes"
   NSTASH_OLD=$(git stash list | wc -l) && \
   git stash && \
-  NSTASH_NEW=$(git stash list | wc -l) || $ERREXIT
+  NSTASH_NEW=$(git stash list | wc -l) || ErrExit
 
   # Update the main branch.
-  UpdateBranch $REMOTE_MAIN $BRANCH_MAIN $BRANCH_MAIN $REMOTE_FORK || $ERREXIT
+  UpdateBranch $REMOTE_MAIN $BRANCH_MAIN $BRANCH_MAIN $REMOTE_FORK || ErrExit
 
   # Update the current branch.
-  [ "$BRANCH" != "$BRANCH_MAIN" ] && { UpdateBranch $REMOTE_MAIN $BRANCH_MAIN $BRANCH $REMOTE_FORK || $ERREXIT; }
+  [ "$BRANCH" != "$BRANCH_MAIN" ] && { UpdateBranch $REMOTE_MAIN $BRANCH_MAIN $BRANCH $REMOTE_FORK || ErrExit; }
 
   # Unstash stashed changes if any.
-  [ $NSTASH_NEW -ne $NSTASH_OLD ] && { MsgSubStep "- Unstashing uncommitted local changes"; git stash pop || $ERREXIT; }
+  [ $NSTASH_NEW -ne $NSTASH_OLD ] && { MsgSubStep "- Unstashing uncommitted local changes"; git stash pop || ErrExit; }
 }
-
-[ "$ALIBUILD_ARCH" ] && ALIBUILD_OPT="-a $ALIBUILD_ARCH" || ALIBUILD_OPT=""
 
 # alidist
 if [ $ALIDIST_UPDATE -eq 1 ]; then
@@ -140,24 +148,48 @@ fi
 if [ $ALIPHYSICS_UPDATE -eq 1 ]; then
   MsgStep "Updating AliPhysics"
   UpdateGit "$ALIPHYSICS_DIR" $ALIPHYSICS_REMOTE_MAIN $ALIPHYSICS_BRANCH_MAIN $ALIPHYSICS_REMOTE_FORK
-  [ $ALIPHYSICS_BUILD -eq 1 ] && { MsgSubStep "- Building AliPhysics"; cd "$ALICE_DIR" && aliBuild build AliPhysics $ALIPHYSICS_BUILD_OPT $ALIBUILD_OPT || $ERREXIT; }
+  [ $ALIPHYSICS_BUILD -eq 1 ] && { MsgSubStep "- Building AliPhysics"; cd "$ALICE_DIR" && aliBuild build AliPhysics $ALIPHYSICS_BUILD_OPT $ALIBUILD_OPT || ErrExit; }
 fi
 
 # O2
 if [ $O2_UPDATE -eq 1 ]; then
   MsgStep "Updating O2"
   UpdateGit "$O2_DIR" $O2_REMOTE_MAIN $O2_BRANCH_MAIN $O2_REMOTE_FORK
-  [ $O2_BUILD -eq 1 ] && { MsgSubStep "- Building O2"; cd "$ALICE_DIR" && aliBuild build O2 $O2_BUILD_OPT $ALIBUILD_OPT || $ERREXIT; }
+  [ $O2_BUILD -eq 1 ] && { MsgSubStep "- Building O2"; cd "$ALICE_DIR" && aliBuild build O2 $O2_BUILD_OPT $ALIBUILD_OPT || ErrExit; }
 fi
-
-# Cleanup
-MsgStep "Cleaning builds"
-aliBuild clean $ALIBUILD_OPT
 
 # Run 3 validation
 if [ $RUN3VALIDATE_UPDATE -eq 1 ]; then
   MsgStep "Updating Run3Analysisvalidation"
   UpdateGit "$RUN3VALIDATE_DIR" $RUN3VALIDATE_REMOTE_MAIN $RUN3VALIDATE_BRANCH_MAIN $RUN3VALIDATE_REMOTE_FORK
+fi
+
+# Cleanup
+  if [ $CLEAN -eq 1 ]; then
+  MsgStep "Cleaning builds"
+
+  # Delete all symlinks to builds and recreate the latest ones to allow deleting of all other builds.
+  if [ $PURGE_BUILDS -eq 1 ]; then
+    MsgWarn "Purging builds"
+    # Delete all symlinks to builds.
+    MsgSubStep "- Deleting symlinks to builds"
+    find "$ALICE_DIR/sw/$ALIBUILD_ARCH/" -mindepth 2 -maxdepth 2 -type l -delete || ErrExit
+    find "$ALICE_DIR/sw/BUILD" -mindepth 1 -maxdepth 1 -type l -delete || ErrExit
+    # Recreate symlinks to the latest builds.
+    MsgSubStep "- Re-building AliPhysics"; cd "$ALICE_DIR" && aliBuild build AliPhysics $ALIPHYSICS_BUILD_OPT $ALIBUILD_OPT > /dev/null 2>&1 || ErrExit
+    MsgSubStep "- Re-building O2"; cd "$ALICE_DIR" && aliBuild build O2 $O2_BUILD_OPT $ALIBUILD_OPT > /dev/null 2>&1 || ErrExit
+  fi
+
+  aliBuild clean $ALIBUILD_OPT
+
+  # Delete store and SOURCES (except for AliPhysics and O2).
+  if [ $CLEAN_AGGRESSIVE -eq 1 ]; then
+    MsgWarn "Cleaning aggressively"
+    #find "$ALICE_DIR/sw/SOURCES" -mindepth 1 -maxdepth 1 ! -name AliPhysics ! -name O2 -exec rm -rf {} \; || ErrExit
+    rm -rf "$ALICE_DIR/sw/TARS/$ALIBUILD_ARCH/store" || ErrExit
+    # Delete broken links.
+    #find -L "$ALICE_DIR/sw/TARS/$ALIBUILD_ARCH" -type l -delete || ErrExit
+  fi
 fi
 
 # Print out latest commits.


### PR DESCRIPTION
- The script is now configurable, i.e. it can perform maintenance on externally provided specifications of repositories.
- A proper purging mode now allows to delete obsolete builds that aliBuild would keep otherwise.