### PR TITLE
Adjust task configuration. Speed up cleanup.

### DIFF
--- a/codeHF/config_tasks.sh
+++ b/codeHF/config_tasks.sh
@@ -20,7 +20,7 @@ DOO2=1              # Run O2 tasks.
 DOPOSTPROCESS=1     # Run output postprocessing. (Compare AliPhysics and O2 output.)
 
 # Disable incompatible steps.
-[ $ISINPUTO2 -eq 1 ] && { DOCONVERT=0; DOALI=0; DOPOSTPROCESS=0; }
+[ $ISINPUTO2 -eq 1 ] && { DOCONVERT=0; DOALI=0; }
 
 # Activation of O2 tasks
 DOO2_QA=0           # qatask

--- a/exec/update_packages.sh
+++ b/exec/update_packages.sh
@@ -245,7 +245,7 @@ if [ $CLEAN -eq 1 ]; then
   MsgStep "Cleaning aliBuild files"
 
   # Get the directory size before cleaning.
-  SIZE_BEFORE=$(du -sb $ALICE_DIR | cut -f1)
+  SIZE_BEFORE=$(du -sb $ALICE_DIR/sw | cut -f1)
 
   # Delete all symlinks to builds and recreate the latest ones to allow deleting of all other builds.
   if [ $PURGE_BUILDS -eq 1 ]; then
@@ -291,7 +291,7 @@ if [ $CLEAN -eq 1 ]; then
   cd "$ALICE_DIR" && aliBuild clean $ALIBUILD_OPT
 
   # Get the directory size after cleaning.
-  SIZE_AFTER=$(du -sb $ALICE_DIR | cut -f1)
+  SIZE_AFTER=$(du -sb $ALICE_DIR/sw | cut -f1)
   # Report size difference.
   SIZE_DIFF=$(( SIZE_BEFORE - SIZE_AFTER ))
   [ "$(which numfmt)" ] && SIZE_DIFF=$(numfmt --to=si --round=nearest -- $SIZE_DIFF) # Convert the number of bytes to a human-readable format.


### PR DESCRIPTION
- Do not skip postprocessing for O2 input.
- Check size difference only in sw.