### PR TITLE
Update run5 json file

### DIFF
--- a/codeHF/config_input.sh
+++ b/codeHF/config_input.sh
@@ -54,4 +54,18 @@ case $INPUT_CASE in
     JSON="$JSONRUN5"
     ISINPUTO2=1
     ISMC=1;;
+  8)
+    INPUT_LABEL="Run 5, p-p MC 14 TeV MB, Scenario 3"
+    INPUT_DIR="/home/mmazzill/pp14TeV_oniaX_10M_sc3_werner_26042021"
+    INPUT_FILES="AODRun5.*.root"
+    JSON="$JSONRUN5"
+    ISINPUTO2=1
+    ISMC=1;;
+  9)
+    INPUT_LABEL="Run 5, p-p MC 14 TeV MB, Scenario 3"
+    INPUT_DIR="/home/mmazzill/pp14TeV_inel_20M_sc3_werner_26042021"
+    INPUT_FILES="AODRun5.*.root"
+    JSON="$JSONRUN5"
+    ISINPUTO2=1
+    ISMC=1;;
 esac

--- a/codeHF/dpl-config_run5.json
+++ b/codeHF/dpl-config_run5.json
@@ -255,10 +255,16 @@
         "d_pidTPCMaxpT": "2000.",
         "d_TPCNClsFindablePIDCut": "-9999",
         "d_nSigmaTPC": "1000.",
-        "pTBins": {
+        "d_pidTOFMinpT": "0.15",
+        "d_pidTOFMaxpT": "15.",
+        "d_pidRICHMinpT": "0.15",
+        "d_pidRICHMaxpT": "15.",
+        "d_nSigmaTPC": "3.",
+        "d_nSigmaTOF": "3.",
+        "d_nSigmaRICH": "3.",
+	"pTBins": {
             "values": [
                 "0",
-                "0.5",
                 "1",
                 "2",
                 "3",
@@ -271,7 +277,6 @@
         },
         "Jpsi_to_ee_cuts": {
             "values": [
-                ["0.5", "0.2", "0.4", "1"],
                 ["0.5", "0.2", "0.4", "1"],
                 ["0.5", "0.2", "0.4", "1"],
                 ["0.5", "0.2", "0.4", "1"],
@@ -363,12 +368,11 @@
         "d_selectionFlagXic": "0"
     },
     "hf-task-jpsi": {
-        "cutYCandMax": "0.8",
+        "cutYCandMax": "1.44",
         "d_selectionFlagJpsi": "0",
         "pTBins": {
             "values": [
                 "0",
-                "0.5",
                 "1",
                 "2",
                 "3",
@@ -381,7 +385,7 @@
         }
     },
     "hf-task-jpsi-mc": {
-        "cutYCandMax": "0.8",
+        "cutYCandMax": "1.44",
         "d_selectionFlagJpsi": "0"
     },
     "hf-task-x": {


### PR DESCRIPTION
- extend rapidity coverage to 1.44
- add new datasets for MB and onia at 14 TeV with finer file-splitting