### PR TITLE
Add new features in make_command_o2

### DIFF
--- a/codeHF/config_tasks.sh
+++ b/codeHF/config_tasks.sh
@@ -173,7 +173,7 @@ function MakeScriptO2 {
 FileIn="\$1"
 JSON="\$2"
 mkdir sockets && \
-$O2EXEC && \
+$O2EXEC && \\
 rm -r sockets
 EOF
 }

--- a/codeHF/workflows.yml
+++ b/codeHF/workflows.yml
@@ -14,7 +14,7 @@ workflows:
 
   o2-analysis-hf-candidate-creator-2prong: &cand_creator
     activate: no
-    dependencies: [o2-analysis-hf-track-index-skims-creator]
+    dependencies: o2-analysis-hf-track-index-skims-creator
     options:
       mc: "--doMC"
     tables:
@@ -33,22 +33,27 @@ workflows:
   o2-analysis-hf-d0-candidate-selector: &selector_2prong
     activate: no
     dependencies: [o2-analysis-hf-candidate-creator-2prong, o2-analysis-pid-tpc-full, o2-analysis-pid-tof-full]
+    tables: HFSELD0CAND
 
   o2-analysis-hf-jpsi-toee-candidate-selector:
     <<: *selector_2prong
     activate: no
+    tables: HFSELJPSICAND
 
   o2-analysis-hf-dplus-topikpi-candidate-selector: &selector_3prong
     activate: no
     dependencies: [o2-analysis-hf-candidate-creator-3prong, o2-analysis-pid-tpc-full, o2-analysis-pid-tof-full]
+    tables: HFSELDPLUSCAND
 
   o2-analysis-hf-lc-candidate-selector:
     <<: *selector_3prong
     activate: no
+    tables: HFSELLCCAND
 
   o2-analysis-hf-xic-topkpi-candidate-selector:
     <<: *selector_3prong
     activate: no
+    tables: HFSELXICCAND
 
   # Analysis tasks
 

--- a/exec/make_command_o2.py
+++ b/exec/make_command_o2.py
@@ -285,7 +285,7 @@ def main():
                 sys.exit(1)
         if opt_local:
             string_wf += " " + opt_local
-        command += " | " + string_wf
+        command += " | \\\n" + string_wf
     if not command:
         msg_err("Nothing to do!")
         sys.exit(1)

--- a/exec/make_command_o2.py
+++ b/exec/make_command_o2.py
@@ -265,6 +265,10 @@ def main():
             string_wf = exec_wf
         else:
             string_wf = wf
+        # Detect duplicate workflows.
+        if string_wf in command:
+            msg_err("Workflow %s is already present." % string_wf)
+            sys.exit(1)
         # Process options.
         if "options" in dic_wf_single:
             opt_wf = dic_wf_single["options"]

--- a/exec/make_command_o2.py
+++ b/exec/make_command_o2.py
@@ -233,6 +233,8 @@ def main():
             elif isinstance(tab_wf, dict):
                 if "default" in tab_wf:
                     join_to_list(tab_wf["default"], tables)
+                if not mc_mode and "real" in tab_wf:
+                    join_to_list(tab_wf["real"], tables)
                 if mc_mode and "mc" in tab_wf:
                     join_to_list(tab_wf["mc"], tables)
             else:
@@ -254,8 +256,16 @@ def main():
         if not dic_wf_single["activate"]:
             continue
         msg_bold("  " + wf)
-        string_wf = wf
-        # Process options
+        # Determine the workflow executable.
+        if "executable" in dic_wf_single:
+            exec_wf = dic_wf_single["executable"]
+            if not isinstance(exec_wf, str):
+                msg_err('"executable" in %s must be str, is %s' % (wf, type(exec_wf)))
+                sys.exit(1)
+            string_wf = exec_wf
+        else:
+            string_wf = wf
+        # Process options.
         if "options" in dic_wf_single:
             opt_wf = dic_wf_single["options"]
             if isinstance(opt_wf, (str, list)):
@@ -263,6 +273,8 @@ def main():
             elif isinstance(opt_wf, dict):
                 if "default" in opt_wf:
                     string_wf += " " + join_strings(opt_wf["default"])
+                if not mc_mode and "real" in opt_wf:
+                    string_wf += " " + join_strings(opt_wf["real"])
                 if mc_mode and "mc" in opt_wf:
                     string_wf += " " + join_strings(opt_wf["mc"])
             else:


### PR DESCRIPTION
* Support options and tables that should be considered only in real-data mode.
* Support workflow aliases (same workflow under different node name in the database with different options).
* Improve style of the content of `script_o2.sh` by printing one workflow per line.
* Detect duplicate workflows, i.e. attempts to add the same workflow multiple times in the O2 command.
* Add tables of selectors in the database.