### PR TITLE
PWGHF: added pT bins to lc-mc task

### DIFF
--- a/codeHF/dpl-config_run3.json
+++ b/codeHF/dpl-config_run3.json
@@ -509,7 +509,22 @@
     },
     "hf-task-lc-mc": {
         "cutYCandMax": "0.8",
-        "d_selectionFlagLc": "0"
+        "d_selectionFlagLc": "0",
+        "ptBins": {
+            "values": [
+                "0",
+                "1",
+                "2",
+                "3",
+                "4",
+                "5",
+                "6",
+                "8",
+                "12",
+                "24",
+                "36"
+            ]
+        }
     },
     "hf-task-xic": {
         "cutEtaCandMax": "0.8",

--- a/codeHF/dpl-config_run5_hf.json
+++ b/codeHF/dpl-config_run5_hf.json
@@ -595,7 +595,22 @@
     },
     "hf-task-lc-mc": {
         "cutYCandMax": "2.0",
-        "d_selectionFlagLc": "0"
+        "d_selectionFlagLc": "0",
+        "ptBins": {
+            "values": [
+                "0",
+                "1",
+                "2",
+                "3",
+                "4",
+                "5",
+                "6",
+                "8",
+                "12",
+                "24",
+                "36"
+            ]
+        }
     },
     "hf-task-xic": {
         "cutEtaCandMax": "-1",


### PR DESCRIPTION
In connection with PR to O2Physics: https://github.com/AliceO2Group/O2Physics/pull/86 .
To synchronise the pT ranges in task-lc and task-lc-mc.