### PR TITLE
Add QA Efficiency configuration to JSON

### DIFF
--- a/codeHF/config_tasks.sh
+++ b/codeHF/config_tasks.sh
@@ -163,10 +163,12 @@ function AdjustJson {
   if [ "$ISMC" -eq 1 ]; then
     MsgWarn "Using MC data"
     ReplaceString "\"processMc\": \"false\"" "\"processMc\": \"true\"" "$JSON" || ErrExit "Failed to edit $JSON."
+    ReplaceString "\"processMC\": \"false\"" "\"processMC\": \"true\"" "$JSON" || ErrExit "Failed to edit $JSON."
     ReplaceString "\"isMC\": \"false\"" "\"isMC\": \"true\"" "$JSON" || ErrExit "Failed to edit $JSON."
   else
     MsgWarn "Using real data"
     ReplaceString "\"processMc\": \"true\"" "\"processMc\": \"false\"" "$JSON" || ErrExit "Failed to edit $JSON."
+    ReplaceString "\"processMC\": \"true\"" "\"processMC\": \"false\"" "$JSON" || ErrExit "Failed to edit $JSON."
     ReplaceString "\"isMC\": \"true\"" "\"isMC\": \"false\"" "$JSON" || ErrExit "Failed to edit $JSON."
   fi
 

--- a/codeHF/dpl-config_run3.json
+++ b/codeHF/dpl-config_run3.json
@@ -1508,6 +1508,60 @@
         "nBinsDeltaEta": "100",
         "nBinsImpactParameter": "2000"
     },
+    "qa-efficiency": {
+        "noFakesHits": "false",
+        "doPositivePDG": "true",
+        "doNegativePDG": "true",
+        "do-un-id": "true",
+        "do-el": "true",
+        "do-mu": "true",
+        "do-pi": "true",
+        "do-ka": "true",
+        "do-pr": "true",
+        "do-de": "true",
+        "do-tr": "true",
+        "do-he": "true",
+        "do-al": "true",
+        "trackSelection": "true",
+        "globalTrackSelection": "0",
+        "nMinNumberOfContributors": "2",
+        "vertex-z-min": "-10",
+        "vertex-z-max": "10",
+        "ptBins": {
+            "values": [
+                "20",
+                "0.1",
+                "10"
+            ]
+        },
+        "log-pt": "0",
+        "etaBins": {
+            "values": [
+                "100",
+                "-0.8",
+                "0.8"
+            ]
+        },
+        "phiBins": {
+            "values": [
+                "100",
+                "0",
+                "6.2839999999999998"
+            ]
+        },
+        "yBins": {
+            "values": [
+                "100",
+                "-0.5",
+                "0.5"
+            ]
+        },
+        "make-eff": "true",
+        "doPtEta": "true",
+        "applyEvSel": "0",
+        "processMC": "true",
+        "processData": "false"
+    },
     "internal-dpl-aod-global-analysis-file-sink": "",
     "internal-dpl-aod-writer": ""
 }


### PR DESCRIPTION
@vkucera @ginnocen FYI

QA Efficiency does not follow our name convention, so it has `processMC` (not: `processMc`) and `processData`.
One needs to remember and set these flags manually.