### PR TITLE
Update configurables and workflow

### DIFF
--- a/codeHF/config_tasks.sh
+++ b/codeHF/config_tasks.sh
@@ -212,12 +212,6 @@ function AdjustJson {
     ReplaceString "\"processNoTrigSel\": \"false\"" "\"processNoTrigSel\": \"true\"" "$JSON" || ErrExit "Failed to edit $JSON."
   fi
 
-  # hf-track-index-skim-creator-tag-sel-tracks, hf-track-index-skim-creator-cascades
-  if [ "$INPUT_RUN" -eq 3 ]; then
-    # do not perform track quality cuts for Run 3 until they are updated
-    ReplaceString "\"doCutQuality\": \"true\"" "\"doCutQuality\": \"false\"" "$JSON" || ErrExit "Failed to edit $JSON."
-  fi
-
   # hf-track-index-skim-creator-cascades
   if [[ $DOO2_CAND_CASC -eq 1 || $DOO2_SEL_LCK0SP -eq 1 || $DOO2_TASK_LCK0SP -eq 1 || $DOO2_TREE_LCK0SP -eq 1 ]]; then
     ReplaceString "\"processCascades\": \"false\"" "\"processCascades\": \"true\"" "$JSON" || ErrExit "Failed to edit $JSON."
@@ -254,9 +248,13 @@ function AdjustJson {
 
   # tof-event-time
   if [ "$INPUT_RUN" -eq 3 ]; then
-    ReplaceString "\"processNoFT0\": \"false\"" "\"processNoFT0\": \"true\"" "$JSON" || ErrExit "Failed to edit $JSON."
-  else
+    ReplaceString "\"processFT0\": \"false\"" "\"processFT0\": \"true\"" "$JSON" || ErrExit "Failed to edit $JSON."
     ReplaceString "\"processNoFT0\": \"true\"" "\"processNoFT0\": \"false\"" "$JSON" || ErrExit "Failed to edit $JSON."
+    ReplaceString "\"processOnlyFT0\": \"true\"" "\"processOnlyFT0\": \"false\"" "$JSON" || ErrExit "Failed to edit $JSON."
+  else
+    ReplaceString "\"processFT0\": \"true\"" "\"processFT0\": \"false\"" "$JSON" || ErrExit "Failed to edit $JSON."
+    ReplaceString "\"processNoFT0\": \"true\"" "\"processNoFT0\": \"false\"" "$JSON" || ErrExit "Failed to edit $JSON."
+    ReplaceString "\"processOnlyFT0\": \"true\"" "\"processOnlyFT0\": \"false\"" "$JSON" || ErrExit "Failed to edit $JSON."
   fi
 
   # hf-task-flow

--- a/codeHF/dpl-config_run3.json
+++ b/codeHF/dpl-config_run3.json
@@ -43,6 +43,9 @@
         "doCutQuality": "true",
         "useIsGlobalTrack": "false",
         "useIsGlobalTrackWoDCA": "false",
+        "useIsGlobalTrackForSoftPion": "false",
+        "useIsGlobalTrackWoDCAForSoftPion": "true",
+        "useIsQualityTrackITSForSoftPion": "false",
         "tpcNClsFoundMin": "70",
         "binsPtTrack": {
             "values": [
@@ -2937,6 +2940,7 @@
         "etaMax": "0.8"
     },
     "track-propagation": {
+        "minPropagationDistance": "83.0999985",
         "processStandard": "false",
         "processCovariance": "true"
     },

--- a/codeHF/dpl-config_run3.json
+++ b/codeHF/dpl-config_run3.json
@@ -42,7 +42,7 @@
         "debug": "false",
         "doCutQuality": "true",
         "useIsGlobalTrack": "false",
-        "useIsGlobalTrackWoDCA": "false",
+        "useIsGlobalTrackWoDCA": "true",
         "useIsGlobalTrackForSoftPion": "false",
         "useIsGlobalTrackWoDCAForSoftPion": "true",
         "useIsQualityTrackITSForSoftPion": "false",
@@ -2940,7 +2940,7 @@
         "etaMax": "0.8"
     },
     "track-propagation": {
-        "minPropagationDistance": "83.0999985",
+        "minPropagationDistance": "5",
         "processStandard": "false",
         "processCovariance": "true"
     },

--- a/codeHF/workflows.yml
+++ b/codeHF/workflows.yml
@@ -482,15 +482,21 @@ workflows:
   o2-analysis-pid-tpc-full:
     dependencies: [o2-analysis-pid-tpc-base, o2-analysis-timestamp]
 
-  o2-analysis-pid-tof-base:
+  o2-analysis-pid-tof-base_run2:
+    executable: o2-analysis-pid-tof-base
     dependencies: o2-analysis-event-selection
 
-  o2-analysis-pid-tof-full_run2: &tof_full
+  o2-analysis-pid-tof-base_run3:
+    executable: o2-analysis-pid-tof-base
+    dependencies: [o2-analysis-event-selection, o2-analysis-ft0-corrected-table]
+
+  o2-analysis-pid-tof-full_run2:
     executable: o2-analysis-pid-tof-full
-    dependencies: [o2-analysis-pid-tof-base, o2-analysis-timestamp]
+    dependencies: [o2-analysis-pid-tof-base_run2, o2-analysis-timestamp]
 
   o2-analysis-pid-tof-full_run3:
-    <<: *tof_full
+    executable: o2-analysis-pid-tof-full
+    dependencies: [o2-analysis-pid-tof-base_run3, o2-analysis-timestamp]
 
   o2-analysis-pid-tof-full_run5:
     executable: o2-analysis-alice3-pid-tof

--- a/codeHF/workflows.yml
+++ b/codeHF/workflows.yml
@@ -475,6 +475,8 @@ workflows:
     executable: o2-analysis-multiplicity-table
     dependencies: o2-analysis-event-selection
 
+  o2-analysis-ft0-corrected-table: {}
+
   # PID
 
   o2-analysis-pid-tpc-base: {}


### PR DESCRIPTION
Hi @vkucera and @DelloStritto ,
Updates based on adjustments I needed to run with Luigi's configuration (Hyperloop wagon HfTrackIndexSkimCreator_SaveDD). Let me know if there should be other default values for the new configurables.

Questions:
1. Should doCutQuality always be false for Run 3 data now? In Luigi's Hyperloop settings it is true.
https://github.com/AliceO2Group/Run3Analysisvalidation/blob/master/codeHF/config_tasks.sh#L218

2. Similarly, for Run 3, we assume no FT0 processing, but Luigi switched it on. That's why I needed to add ft0 dependency in workflows.yml to tof-base. Are these lines still valid?
https://github.com/AliceO2Group/Run3Analysisvalidation/blob/master/codeHF/config_tasks.sh#L257